### PR TITLE
Allow creation of HubConnectionManager using an existing HubConnection.

### DIFF
--- a/HubConnectionManager/HubConnectionManager.cs
+++ b/HubConnectionManager/HubConnectionManager.cs
@@ -36,14 +36,19 @@ namespace HubConnectionManager
             get { return _hubConnection.State; }
         }
 
-        private HubConnectionManager(string url)
+        private HubConnectionManager(HubConnection hubConnection)
         {
-            _hubConnection = new HubConnection(url);
+            _hubConnection = hubConnection;
         }
 
         public static IHubConnectionManager GetHubConnectionManager(string url)
         {
-            IHubConnectionManager connectionManager = new HubConnectionManager(url);
+            return GetHubConnectionManager(new HubConnection(url));
+        }
+
+        public static IHubConnectionManager GetHubConnectionManager(HubConnection hubConnection)
+        {
+            IHubConnectionManager connectionManager = new HubConnectionManager(hubConnection);
             return connectionManager;
         }
 

--- a/HubConnectionManager/HubConnectionManager.cs
+++ b/HubConnectionManager/HubConnectionManager.cs
@@ -36,6 +36,11 @@ namespace HubConnectionManager
             get { return _hubConnection.State; }
         }
 
+        private HubConnectionManager(string url)
+        {
+            _hubConnection = new HubConnection(url);
+        }
+
         private HubConnectionManager(HubConnection hubConnection)
         {
             _hubConnection = hubConnection;
@@ -43,7 +48,8 @@ namespace HubConnectionManager
 
         public static IHubConnectionManager GetHubConnectionManager(string url)
         {
-            return GetHubConnectionManager(new HubConnection(url));
+            IHubConnectionManager connectionManager = new HubConnectionManager(url);
+            return connectionManager;
         }
 
         public static IHubConnectionManager GetHubConnectionManager(HubConnection hubConnection)


### PR DESCRIPTION
This allows users to customise the HubConnection that is managed. For example adding headers to the connection.

This is necessary for my own usage because my SignalR endpoint authorizes the user with a bearer token in the headers.
