### PR TITLE
#2 Clients can stop connection without triggering restart attempt.

### DIFF
--- a/HubConnectionManager/HubConnectionManager.cs
+++ b/HubConnectionManager/HubConnectionManager.cs
@@ -170,5 +170,10 @@ namespace HubConnectionManager
                 StateChanged(stateChange);
             }
         }
+
+        public void Dispose()
+        {
+            Stop();
+        }
     }
 }

--- a/HubConnectionManager/HubConnectionManager.cs
+++ b/HubConnectionManager/HubConnectionManager.cs
@@ -65,79 +65,110 @@ namespace HubConnectionManager
             return connectionManager;
         }
 
-        public async Task Initialize()
-        {
-            _hubConnection.Received += s =>
-            {
-                if (Received != null)
-                {
-                    Received(s);
-                }
-            };
-            _hubConnection.Closed += async () =>
-            {
-                if (Closed != null)
-                {
-                    Closed();
-                }
-
-                await TaskEx.Delay(RetryPeriod);
-                try
-                {
-                    await _hubConnection.Start();
-                }
-                catch (Exception ex)
-                {
-                    //NOTE: Unable to connect...again.
-                }
-            };
-            _hubConnection.Reconnecting += () =>
-            {
-                if (Reconnecting != null)
-                {
-                    Reconnecting();
-                }
-            };
-            _hubConnection.Reconnected += () =>
-            {
-                if (Reconnected != null)
-                {
-                    Reconnected();
-                }
-            };
-            _hubConnection.ConnectionSlow += () =>
-            {
-                if (ConnectionSlow != null)
-                {
-                    ConnectionSlow();
-                }
-            };
-            _hubConnection.Error += e =>
-            {
-                if (Error != null)
-                {
-                    Error(e);
-                }
-            };
-            _hubConnection.StateChanged += e =>
-            {
-                if (StateChanged != null)
-                {
-                    StateChanged(e);
-                }
-            };
-            
-            await _hubConnection.Start();
-        }
-
         public IHubProxy CreateHubProxy(string hubName)
         {
             if (string.IsNullOrEmpty(hubName))
             {
                 throw new ArgumentNullException("hubName");
             }
-            
+
             return _hubConnection.CreateHubProxy(hubName);
+        }
+
+        public async Task Initialize()
+        {
+            _hubConnection.Received += OnReceived;
+            _hubConnection.Closed += OnClosed;
+            _hubConnection.Reconnecting += OnReconnecting;
+            _hubConnection.Reconnected += OnReconnected;
+            _hubConnection.ConnectionSlow += OnConnectionSlow;
+            _hubConnection.Error += OnError;
+            _hubConnection.StateChanged += OnStateChanged;
+
+            await _hubConnection.Start();
+        }
+
+        public void Stop()
+        {
+            _hubConnection.Received -= OnReceived;
+            _hubConnection.Closed -= OnClosed;
+            _hubConnection.Reconnecting -= OnReconnecting;
+            _hubConnection.Reconnected -= OnReconnected;
+            _hubConnection.ConnectionSlow -= OnConnectionSlow;
+            _hubConnection.Error -= OnError;
+            _hubConnection.StateChanged -= OnStateChanged;
+
+            _hubConnection.Stop();
+        }
+
+        private void OnReceived(string data)
+        {
+            if (Received != null)
+            {
+                Received(data);
+            }
+        }
+
+        private async void OnClosed()
+        {
+            if (Closed != null)
+            {
+                Closed();
+            }
+            await RetryConnection();
+        }
+
+        private async Task RetryConnection()
+        {
+            await TaskEx.Delay(RetryPeriod);
+            try
+            {
+                await _hubConnection.Start();
+            }
+            catch (Exception ex)
+            {
+                //NOTE: Unable to connect...again.
+            }
+        }
+
+        private void OnReconnecting()
+        {
+            if (Reconnecting != null)
+            {
+                Reconnecting();
+            }
+        }
+
+        private void OnReconnected()
+        {
+            if (Reconnected != null)
+            {
+                Reconnected();
+            }
+        }
+
+        private void OnConnectionSlow()
+        {
+            if (ConnectionSlow != null)
+            {
+                ConnectionSlow();
+            }
+        }
+
+        private void OnError(Exception error)
+        {
+            if (Error != null)
+            {
+                Error(error);
+            }
+        }
+
+        private void OnStateChanged(StateChange stateChange)
+        {
+            if (StateChanged != null)
+            {
+                StateChanged(stateChange);
+            }
         }
     }
 }

--- a/HubConnectionManager/IHubConnectionManager.cs
+++ b/HubConnectionManager/IHubConnectionManager.cs
@@ -17,7 +17,8 @@ namespace HubConnectionManager
         event Action Reconnected;
         event Action ConnectionSlow;
         event Action<StateChange> StateChanged;
-        Task Initialize();
         IHubProxy CreateHubProxy(string hubName);
+        Task Initialize();
+        void Stop();
     }
 }

--- a/HubConnectionManager/IHubConnectionManager.cs
+++ b/HubConnectionManager/IHubConnectionManager.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNet.SignalR.Client.Transports;
 
 namespace HubConnectionManager
 {
-    public interface IHubConnectionManager
+    public interface IHubConnectionManager : IDisposable
     {
         int RetryPeriod { get; set; }
         ConnectionState State { get; }


### PR DESCRIPTION
Potential approach for issue #2. The diff looks a bit muddled, but basically I pulled all of the event handlers out in to actual methods rather than lambdas, which are then subscribed to in `Initialize()` and unsubscribed from in `Stop()`. It is probably easier to look at the raw file than the diff for review purposes.
